### PR TITLE
sendtofile: add support for sending folders recursively 

### DIFF
--- a/jupyter_micropython_kernel/kernel.py
+++ b/jupyter_micropython_kernel/kernel.py
@@ -375,10 +375,17 @@ class MicroPythonKernel(Kernel):
                             self.sres("Cannot excecute folder\n", 31)
                         for root, dirs, files in os.walk(apargs.source):
                             for fn in files:
-                                relpath = os.path.relpath(os.path.join(root, fn), apargs.source)
-                                destpath = os.path.join(destfn, relpath).replace('\\', '/')
-                                filecontents = open(os.path.join(root, fn), mode).read()
-                                sendtofile(destpath, filecontents)
+                                skip = False
+                                fp = os.path.join(root, fn)
+                                relpath = os.path.relpath(fp, apargs.source)
+                                if relpath.endswith('.py'):
+                                    # Check for compiled copy, skip py if exists
+                                    if os.path.exists(fp[:-3] + '.mpy'):
+                                        skip = True
+                                if not skip:
+                                    destpath = os.path.join(destfn, relpath).replace('\\', '/')
+                                    filecontents = open(os.path.join(root, fn), mode).read()
+                                    sendtofile(destpath, filecontents)
             else:
                 self.sres(ap_sendtofile.format_help())
             return cellcontents   # allows for repeat %sendtofile in same cell


### PR DESCRIPTION
This extends the %sendtofile command to allow sending entire folders to the micropython board.

If the source path points to a folder, the whole folder is uploaded to the destination given.
Source files or cell still operates as it did previously.

There is also a simple filter in place in folder mode so if you've compiled your py files into mpy already the folder upload skips the python files and just uploads the mpy files.