### PR TITLE
Use distribution of mpy-cross as default for %mpy-cross command

### DIFF
--- a/jupyter_micropython_kernel/kernel.py
+++ b/jupyter_micropython_kernel/kernel.py
@@ -3,6 +3,8 @@ from ipykernel.kernelbase import Kernel
 import logging, sys, time, os, re
 import serial, socket, serial.tools.list_ports, select
 import websocket  # only for WebSocketConnectionClosedException
+import mpy_cross
+from glob import glob
 from . import deviceconnector
 
 logger = logging.getLogger(__name__)
@@ -231,13 +233,11 @@ class MicroPythonKernel(Kernel):
             if apargs and apargs.set_exe:
                 self.mpycrossexe = apargs.set_exe
             elif apargs.pyfile:
-                if self.mpycrossexe:
-                    self.dc.mpycross(self.mpycrossexe, apargs.pyfile)
-                else:
-                    self.sres("Cross compiler executable not yet set\n", 31)
-                    self.sres("try: %mpy-cross --set-exe /home/julian/extrepositories/micropython/mpy-cross/mpy-cross\n")
-                if self.mpycrossexe:
-                    self.mpycrossexe = "/home/julian/extrepositories/micropython/mpy-cross/mpy-cross"
+                if not self.mpycrossexe:
+                    self.mpycrossexe = mpy_cross.mpy_cross
+
+                for pyfile in glob(apargs.pyfile):
+                    self.dc.mpycross(self.mpycrossexe, pyfile)
             else:
                 self.sres(ap_mpycross.format_help())
             return cellcontents.strip() and cellcontents or None

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,6 @@ setup(name='jupyter_micropython_kernel',
       url='https://github.com/goatchurchprime/jupyter_micropython_kernel',
       license='GPL3',
       packages=['jupyter_micropython_kernel'],
-      install_requires=['pyserial>=3.4', 'websocket-client>=0.44']
+      install_requires=['pyserial>=3.4', 'websocket-client>=0.44', 'mpy-cross']
 )
 


### PR DESCRIPTION
So I've gone and made an auto-compiler for mpy-cross:
https://gitlab.com/alelec/mpy_cross

It builds copies of mpy-cross for osx, linux (32 and 64 bit) and windows (32 and 64 bit).
Every micropython tag and master once a week.

Tag releases are bundled into python wheels and released on pypi, ready for use here :-)
https://pypi.python.org/pypi/mpy-cross

This PR brings in mpy_cross as a dependency and then uses the bundled binary by default. 
This can still be overridden with the original `set-exe` if needed.

Also now supports '*' in filename to run on multiple files