### PR TITLE
%sendtofile clean folder uploads

### DIFF
--- a/jupyter_micropython_kernel/deviceconnector.py
+++ b/jupyter_micropython_kernel/deviceconnector.py
@@ -333,6 +333,29 @@ class DeviceConnector:
             break   # out of the for loop
         return True
 
+    def rmtree(self, top):
+        sswrite = self.workingserial.write  if self.workingserial  else self.workingwebsocket.send
+        sswrite(
+            b'def rmtree(top):\r\n'
+            b'  import os\r\n'
+            b'  try:  os.remove(top)\r\n'
+            b'  except OSError:  pass\r\n'
+            b'  try:\r\n'
+            b'    for e in os.listdir(top):\r\n'
+            b'      p = "/".join((top,e))\r\n'
+            b'      try:  os.remove(p)\r\n'
+            b'      except:  rmtree(p)\r\n'
+            b'    os.rmdir(top)\r\n'
+            b'  except OSError:  pass\r\n'
+            b'  done = False\r\n'
+            b'  try:  os.stat(top)\r\n'
+            b'  except OSError:  done = True\r\n'
+            b'  return done\r\n\r\n'
+        )
+        sswrite('if not rmtree({}):  print("Failed to delete original {}")\r\n'.format(repr(top), top).encode())
+        sswrite(b'del rmtree\r\n')
+        sswrite(b'\r\x04')  # intermediate execution
+        self.receivestream(bseekokay=True)  # Wait for it to execute
 
     def sendtofile(self, destinationfilename, bmkdir, bappend, bbinary, bquiet, filecontents):
         if not (self.workingserial or self.workingwebsocket):

--- a/jupyter_micropython_kernel/kernel.py
+++ b/jupyter_micropython_kernel/kernel.py
@@ -377,13 +377,17 @@ class MicroPythonKernel(Kernel):
                     if os.path.isfile(apargs.source):
                         filecontents = open(apargs.source, mode).read()
                         if apargs.execute:
-                            self.sres("Cannot excecute sourced file\n", 31)
+                            self.sres("Cannot execute sourced file\n", 31)
                         sendtofile(destfn, filecontents)
 
                     elif os.path.isdir(apargs.source):
                         if apargs.execute:
-                            self.sres("Cannot excecute folder\n", 31)
+                            self.sres("Cannot execute folder\n", 31)
                         for root, dirs, files in os.walk(apargs.source):
+
+                            if apargs.mkdir:
+                                self.dc.rmtree(destfn)
+
                             for fn in files:
                                 skip = False
                                 fp = os.path.join(root, fn)


### PR DESCRIPTION
When uploading an entire folder to the device, if --mkdir is specified, then delete any existing copy of the folder before uploading new copy.

I think it feels natural that when uploading a folder, it will replace any existing copy of that folder, just like a file upload replaces the existing file.
The previous implementation just copies files up, essentially merging the folders together. 
There was no existing means of deleting files that already existed in the folder.

Clean copies of the folder upload is far more useful in my opinion.