### PR TITLE
%fetchfromfile saved file is empty due to TypeError

### DIFF
--- a/jupyter_micropython_kernel/kernel.py
+++ b/jupyter_micropython_kernel/kernel.py
@@ -385,7 +385,7 @@ class MicroPythonKernel(Kernel):
                     dstfile = apargs.destinationfilename or os.path.basename(apargs.sourcefilename)
                     self.sres("Saving file to {}".format(repr(dstfile)))
                     fout = open(dstfile, "wb" if apargs.binary else "w")
-                    fout.write(fetchedcontents)
+                    fout.write(str(fetchedcontents))
                     fout.close()
                     
                 if apargs.load:


### PR DESCRIPTION
I got this error under python 3.8:

[IPKernelApp] ERROR | Exception in message handler:
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/ipykernel/kernelbase.py", line 264, in dispatch_shell
    yield gen.maybe_future(handler(stream, idents, msg))
  File "/usr/local/lib/python3.8/dist-packages/tornado/gen.py", line 762, in run
    value = future.result()
  File "/usr/local/lib/python3.8/dist-packages/tornado/gen.py", line 234, in wrapper
    yielded = ctx_run(next, result)
  File "/usr/local/lib/python3.8/dist-packages/ipykernel/kernelbase.py", line 539, in execute_request
    self.do_execute(
  File "/home/user/.local/share/jupyter/jupyter_micropython_kernel/jupyter_micropython_kernel/kernel.py", line 590, in do_execute
    set_next_input_payload = self.sendcommand(code)
  File "/home/user/.local/share/jupyter/jupyter_micropython_kernel/jupyter_micropython_kernel/kernel.py", line 498, in sendcommand
    cellcontents = self.interpretpercentline(mpercentline.group(1), cellcontents[mpercentline.end():])   # discards the %command and a single blank line (if there is one) from the cell contents
  File "/home/user/.local/share/jupyter/jupyter_micropython_kernel/jupyter_micropython_kernel/kernel.py", line 388, in interpretpercentline
    fout.write(fetchedcontents)
TypeError: write() argument must be str, not bytes

I solved it by type cast. I hope it's ok for compatibility.