### PR TITLE
Enable to use int values in %esptool and %serialconnect to --port

### DIFF
--- a/jupyter_micropython_kernel/kernel.py
+++ b/jupyter_micropython_kernel/kernel.py
@@ -157,19 +157,22 @@ class MicroPythonKernel(Kernel):
             apargs = parseap(ap_serialconnect, percentstringargs[1:])
             
             self.dc.disconnect(apargs.verbose)
-            self.dc.serialconnect(apargs.port, apargs.baud, apargs.verbose)
-            if self.dc.workingserial:
-                if not apargs.raw:
-                    if self.dc.enterpastemode(verbose=apargs.verbose):
-                        self.sresSYS("Ready.\n")
-                    else:
-                        self.sres("Disconnecting [paste mode not working]\n", 31)
-                        self.dc.disconnect(verbose=apargs.verbose)
-                        self.sresSYS("  (You may need to reset the device)")
-                        cellcontents = ""
-            else:
-                cellcontents = ""
-            return cellcontents.strip() and cellcontents or None
+            try:
+                apargs.port = int(apargs.port)
+            finally:
+                self.dc.serialconnect(apargs.port, apargs.baud, apargs.verbose)
+                if self.dc.workingserial:
+                    if not apargs.raw:
+                        if self.dc.enterpastemode(verbose=apargs.verbose):
+                            self.sresSYS("Ready.\n")
+                        else:
+                            self.sres("Disconnecting [paste mode not working]\n", 31)
+                            self.dc.disconnect(verbose=apargs.verbose)
+                            self.sresSYS("  (You may need to reset the device)")
+                            cellcontents = ""
+                else:
+                    cellcontents = ""
+                return cellcontents.strip() and cellcontents or None
 
         if percentcommand == ap_websocketconnect.prog:
             apargs = parseap(ap_websocketconnect, percentstringargs[1:])

--- a/jupyter_micropython_kernel/kernel.py
+++ b/jupyter_micropython_kernel/kernel.py
@@ -218,7 +218,10 @@ class MicroPythonKernel(Kernel):
         if percentcommand == ap_esptool.prog:
             apargs = parseap(ap_esptool, percentstringargs[1:])
             if apargs and (apargs.espcommand == "erase" or apargs.binfile):
-                self.dc.esptool(apargs.espcommand, apargs.port, apargs.binfile)
+                try:
+                    apargs.port = int(apargs.port)
+                finally:
+                    self.dc.esptool(apargs.espcommand, apargs.port, apargs.binfile)
             else:
                 self.sres(ap_esptool.format_help())
                 self.sres("Please download the bin file from https://micropython.org/download/#{}".format(apargs.espcommand if apargs else ""))

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,13 @@
+from setuptools import setup
+
+setup(name='jupyter_micropython_kernel',
+      version='0.1.3',
+      description='Jupyter notebook kernel for operating Micropython.',
+      author='Julian Todd, Tony DiCola',
+      author_email='julian@goatchurch.org.uk',
+      keywords='jupyter micropython',
+      url='https://github.com/goatchurchprime/jupyter_micropython_kernel',
+      license='GPL3',
+      packages=['jupyter_micropython_kernel'],
+      install_requires=['pyserial>=3.4', 'websocket-client>=0.44']
+)


### PR DESCRIPTION
Hello,
When using several devices, knowing which port is ready can be a problem, here is a workaround allowing to give integers values to choose the serial port (you can still give a port by path).

Use :

Cell 1:
%serialconnect --port=0
print("First Device")

Cell 2:
%serialconnect --port=1
print("Second Device")

I know you deleted setup.py previously, but it is a problem while wanting to build our own kernel, therefore i think it should get back here.

This work has been done during my M1 internship at LS2N lab, Polytech Nantes in Summer 2021
Prof. Parrein (@bparrein) and Prof. BAKOWSKI